### PR TITLE
demo: also look for debug versions of the Poco libs

### DIFF
--- a/demo/poco-websockets/FindPOCO.cmake
+++ b/demo/poco-websockets/FindPOCO.cmake
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 find_path(POCO_INCLUDE_DIR NAMES Poco/Poco.h)
-find_library(POCO_LIBRARY NAMES PocoFoundation)
-find_library(POCO_NET_LIBRARY NAMES PocoNet)
+find_library(POCO_LIBRARY NAMES PocoFoundation PocoFoundationd)
+find_library(POCO_NET_LIBRARY NAMES PocoNet PocoNetd)
 
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
If you build Poco from source, and with debug only, then the demo
fails to build because it doesn't look for Poco libraries ending in
'd'. This logic is the same as in the top-level directory.

Signed-off-by: Andrew McDermott <aim@frobware.com>