### PR TITLE
cmake: allows poco to be found in a non-standard location

### DIFF
--- a/FindPOCO.cmake
+++ b/FindPOCO.cmake
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_path(POCO_INCLUDE_DIR NAMES Poco/Poco.h)
+find_path(POCO_INCLUDE_DIR NAMES Poco/Poco.h PATHS ${POCO_INCLUDE_PATH})
 # POCO insists on appending 'd' to the library names in debug mode
-find_library(POCO_LIBRARY NAMES PocoFoundation PocoFoundationd)
-find_library(POCO_NET_LIBRARY NAMES PocoNet PocoNetd)
+find_library(POCO_LIBRARY NAMES PocoFoundation PocoFoundationd PATHS ${POCO_LIBRARY_PATH})
+find_library(POCO_NET_LIBRARY NAMES PocoNet PocoNetd PATHS ${POCO_LIBRARY_PATH})
 
 
 include(FindPackageHandleStandardArgs)

--- a/demo/poco-websockets/FindPOCO.cmake
+++ b/demo/poco-websockets/FindPOCO.cmake
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_path(POCO_INCLUDE_DIR NAMES Poco/Poco.h)
-find_library(POCO_LIBRARY NAMES PocoFoundation PocoFoundationd)
-find_library(POCO_NET_LIBRARY NAMES PocoNet PocoNetd)
+find_path(POCO_INCLUDE_DIR NAMES Poco/Poco.h PATHS ${POCO_INCLUDE_PATH})
+find_library(POCO_LIBRARY NAMES PocoFoundation PocoFoundationd PATHS ${POCO_LIBRARY_PATH})
+find_library(POCO_NET_LIBRARY NAMES PocoNet PocoNetd PATHS ${POCO_LIBRARY_PATH})
 
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
I built poco and installed it into /usr/local/poco-1.7.7. This change
allows that version to be found by invoking cmake as:

  $ cmake \
      -DPOCO_INCLUDE_PATH=/usr/local/poco-1.7.7/include \
      -DPOCO_LIBRARY_PATH=/usr/local/poco-1.7.7/lib

The rationale for this change is that the packaged version of poco is
too old on ubuntu xenial. However, for development, I did not want to
install version 1.7.7 in /usr/local, hence the requirement to look in
an alternaive location.

The build-and-test.sh shell fragement could be updated to use this
mechanism too (not done).

Signed-off-by: Andrew McDermott <aim@frobware.com>