### PR TITLE
ds-client: allow endpoint to be specified on CLI

### DIFF
--- a/src/ds-client.cpp
+++ b/src/ds-client.cpp
@@ -27,7 +27,7 @@ int main(int argc, char *argv[])
     }
 
     try {
-	deepstream::Client client(uri.c_str());
+	deepstream::Client client(uri);
 
 	if (client.login()) {
 	    std::cout << "successfully logged in to " << uri << std::endl;

--- a/src/ds-client.cpp
+++ b/src/ds-client.cpp
@@ -33,11 +33,11 @@ int main(int argc, char *argv[])
 	    std::cout << "successfully logged in to " << uri << std::endl;
 	    return EXIT_SUCCESS;
 	} else {
-	    std::cout << "failed to login to " << uri << std::endl;
+	    std::cerr << "failed to login to " << uri << std::endl;
 	    return EXIT_FAILURE;
 	}
     } catch(std::exception& e) {
-	std::cout << "Caught exception \"" << e.what() << "\"" << std::endl;
+	std::cerr << "Caught exception \"" << e.what() << "\"" << std::endl;
 	return EXIT_FAILURE;
     }
 }

--- a/src/ds-client.cpp
+++ b/src/ds-client.cpp
@@ -13,24 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <cstdio>
-
+#include <iostream>
 #include <exception>
 
 #include <deepstream.hpp>
 
-int main()
-try
+int main(int argc, char *argv[])
 {
-	deepstream::Client client("ws://localhost:6020/deepstream");
+    std::string uri = "ws://localhost:6020/deepstream";
 
-	if( client.login() )
-		std::printf( "Client logged in\n" );
-	else
-		std::printf( "Client not logged in\n" );
-}
-catch(std::exception& e)
-{
-	fprintf( stderr, "error: '%s'\n", e.what() );
-	return 1;
+    if (argc >= 2) {
+	uri = argv[1];
+    }
+
+    try {
+	deepstream::Client client(uri.c_str());
+
+	if (client.login()) {
+	    std::cout << "successfully logged in to " << uri << std::endl;
+	    return EXIT_SUCCESS;
+	} else {
+	    std::cout << "failed to login to " << uri << std::endl;
+	    return EXIT_FAILURE;
+	}
+    } catch(std::exception& e) {
+	std::cout << "Caught exception \"" << e.what() << "\"" << std::endl;
+	return EXIT_FAILURE;
+    }
 }


### PR DESCRIPTION
Allows websocket endpoint to be specified on the command line as
opposed to being hard coded. If nothing is specified it uses the
existing default of "ws://localhost/deepstream".

For example:

    $ ./src/ds-client
    Caught exception "Connection refused"

    $ ./src/ds-client ws://10.175.102.61:6020/deepstream
    successfully logged in to ws://10.175.102.61:6020/deepstream

I also took the liberty to make the code look like and consistently
use common C++ idioms via-a-vis some C++ and some C IO. And I also
chose to reformat it according to the `stroustrup` coding style.

The client now returns and exits with EXIT_SUCCESS when the client can
successfully connect, or EXIT_FAILURE on any other error.

Signed-off-by: Andrew McDermott <aim@frobware.com>