### PR TITLE
cmake: added missing include dirs

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,7 @@ function(add_boost_test FILENAME DEPENDENCY_LIB)
 	get_filename_component(TEST_EXECUTABLE ${FILENAME} NAME_WE)
 	add_executable(${TEST_EXECUTABLE} ${FILENAME})
 	target_compile_definitions(${TEST_EXECUTABLE} PUBLIC -DBOOST_TEST_DYN_LINK)
+	target_include_directories(${TEST_EXECUTABLE} PUBLIC ${Boost_INCLUDE_DIRS})
 	target_link_libraries(${TEST_EXECUTABLE} ${DEPENDENCY_LIB})
 	target_link_libraries(${TEST_EXECUTABLE} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
 


### PR DESCRIPTION
Fixes the following build error on OSX:

Building CXX object test/CMakeFiles/lexer.dir/lexer.cpp.o
deepstream.io-client-cpp/test/lexer.cpp:18:10: fatal error: 'boost/test/unit_test.hpp' file not found