### PR TITLE
Remove boost dependency when building libdeepstream (#47)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,20 @@
 cmake_minimum_required(VERSION 2.8.12)
 
-project(deepstream.io-client-c++)
+if(NOT BUILD_TESTING)
+  set(BUILD_TESTING OFF CACHE STRING "Build tests. Options are OFF ON." FORCE)
+endif()
+
+if(NOT BUILD_COVERAGE)
+  set(BUILD_COVERAGE OFF CACHE STRING "Build with --coverage; options are OFF ON." FORCE)
+endif()
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release CACHE STRING
       "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel."
       FORCE)
 endif()
+
+project(deepstream.io-client-cpp)
 
 enable_language(C)
 enable_language(CXX)
@@ -67,9 +75,8 @@ else()
   message(FATAL_ERROR "Compiler ${CMAKE_C_COMPILER} has no C11 support.")
 endif()
 
-option(BUILD_TESTING "Build tests" OFF)
-
 if(BUILD_TESTING)
+  find_package(Boost 1.46 REQUIRED COMPONENTS unit_test_framework)
   enable_testing()
 endif()
 
@@ -83,8 +90,6 @@ if(NOT DEFINED(CMAKE_BUILD_TYPE) OR "Debug" STREQUAL "${CMAKE_BUILD_TYPE}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_DEBUG_PEDANTIC")
   endif()
 endif()
-
-option(BUILD_COVERAGE "Build with code coverage" OFF)
 
 if(BUILD_COVERAGE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
@@ -115,6 +120,8 @@ externalproject_add(poco
   UPDATE_COMMAND ""
 )
 
+find_package(FLEX 2.5 REQUIRED)
+
 link_directories(${CMAKE_BINARY_DIR}/thirdparty/lib)
 include_directories(${CMAKE_BINARY_DIR}/thirdparty/include)
 
@@ -123,7 +130,10 @@ include_directories("include")
 add_subdirectory(doc)
 add_subdirectory(include)
 add_subdirectory(src)
-add_subdirectory(test)
+
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()
 
 message(STATUS "CMAKE_SYSTEM=${CMAKE_SYSTEM}")
 message(STATUS "CMAKE_SYSTEM_NAME=${CMAKE_SYSTEM_NAME}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,3 @@
-find_package(Boost 1.46 REQUIRED)
-find_package(FLEX 2.5 REQUIRED)
-
 add_custom_command(
 	OUTPUT
 		${CMAKE_CURRENT_BINARY_DIR}/lexer.c
@@ -42,7 +39,6 @@ add_library(
 
 set_target_properties(libdeepstream PROPERTIES OUTPUT_NAME deepstream)
 target_include_directories(libdeepstream PUBLIC "${CMAKE_BINARY_DIR}/include")
-target_include_directories(libdeepstream PUBLIC ${Boost_INCLUDE_DIRS})
 target_link_libraries(libdeepstream PUBLIC PocoFoundation PocoNet)
 
 install(TARGETS libdeepstream DESTINATION "lib")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,12 +1,3 @@
-if(NOT BUILD_TESTING)
-	return()
-endif()
-
-
-find_package(Boost 1.46 REQUIRED COMPONENTS unit_test_framework)
-find_package(FLEX 2.5 REQUIRED)
-
-
 # This functions searches all unit tests implemented with boost.test and turns
 # each of them into a single CTest test case. See `doc/ctest-vs-boost.md` for
 # the motivation behind this.


### PR DESCRIPTION
The Boost dependencies are only required when testing.

Testing is enabled via:

    $ cmake -DBUILD_TESTING=ON

which will check for the presence of the boost testing libraries.

On ubuntu they can be installed via:

    $ apt install libboost-dev libboost-test-dev

If the boost libraries cannot be found cmake will fail the initial
configuration step.

Closes #47

Signed-off-by: Andrew McDermott <aim@frobware.com>