### PR TITLE
state: simplify transition when already CONNECTED

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -116,30 +116,8 @@ namespace client {
             return State::DISCONNECTED;
         }
 
-        if (state == State::CONNECTED && topic == Topic::EVENT) {
-            if (action == Action::LISTEN || action == Action::SUBSCRIBE || action == Action::UNLISTEN || action == Action::UNSUBSCRIBE || action == Action::LISTEN_ACCEPT || action == Action::LISTEN_REJECT) {
-                if ((sender == Sender::CLIENT && !is_ack) || (sender == Sender::SERVER && is_ack))
-                    return state;
-            } else if (action == Action::EVENT) {
-                return state;
-            } else if (action == Action::SUBSCRIPTION_FOR_PATTERN_FOUND || action == Action::SUBSCRIPTION_FOR_PATTERN_REMOVED) {
-                assert(!is_ack);
-
-                if (sender == Sender::SERVER)
-                    return state;
-            }
-        }
-
-        if (state == State::CONNECTED && topic == Topic::PRESENCE) {
-            if (action == Action::SUBSCRIBE || action == Action::UNSUBSCRIBE || action == Action::QUERY) {
-                if ((sender == Sender::CLIENT && !is_ack) || (sender == Sender::SERVER && is_ack))
-                    return state;
-            }
-            if (action == Action::PRESENCE_JOIN || action == Action::PRESENCE_LEAVE) {
-                if (sender == Sender::SERVER)
-                    return state;
-            }
-        }
+        if (state == State::CONNECTED)
+            return state;
 
         return State::ERROR;
     }

--- a/src/ds-example.cpp
+++ b/src/ds-example.cpp
@@ -61,9 +61,6 @@ int main(int argc, char* argv[])
         return true;
     });
 
-#if 0
-    // List all present users
-    // FIXME: "Sudden disconnect" errors
     client.presence.get_all([](const Presence::UserList users){
         std::cout << "Users: " << std::endl;
 
@@ -72,7 +69,7 @@ int main(int argc, char* argv[])
             std::cout << "\t" << user_str << std::endl;
         }
     });
-#endif
+
     while (true) {
         client.process_messages();
     }


### PR DESCRIPTION
You can't transition out of OPEN unless you lose the connection. In
the future there will be a CLOSING event, but we don't have that right
now.

Fix ds-example to use presence.get_all(). It was previously commented
out due to 'sudden disconnect' - the sudden disconnects were due to
the bad state transition.

Signed-off-by: Andrew McDermott <aim@frobware.com>