### PR TITLE
Use flex_target for building lexer components

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -4,4 +4,5 @@ install(
 	DIRECTORY ./
 	DESTINATION "include"
 	FILES_MATCHING REGEX ".+[.](h|hpp)"
+	PATTERN "lexer.h" EXCLUDE
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,18 +3,9 @@ find_package(Threads REQUIRED)
 
 find_package(OpenSSL REQUIRED)
 
-add_custom_command(
-	OUTPUT
-		${CMAKE_CURRENT_BINARY_DIR}/lexer.c
-		${CMAKE_BINARY_DIR}/include/lexer.h
-	DEPENDS lexer.l
-	COMMAND ${FLEX_EXECUTABLE}
-		--outfile=${CMAKE_CURRENT_BINARY_DIR}/lexer.c
-		--header-file=${CMAKE_BINARY_DIR}/include/lexer.h
-		-- ${CMAKE_CURRENT_SOURCE_DIR}/lexer.l
-	COMMENT "[FLEX][src] Building lexer with Flex ${FLEX_VERSION}"
-	VERBATIM
-)
+flex_target(lexer
+  ${CMAKE_SOURCE_DIR}/src/lexer.l
+  ${CMAKE_CURRENT_BINARY_DIR}/lexer.c)
 
 set_source_files_properties(
 	"${CMAKE_CURRENT_BINARY_DIR}/lexer.c"
@@ -40,7 +31,7 @@ add_library(
 	websockets.cpp
 	websockets/poco.cpp
 	websockets/pseudo.cpp
-	"${CMAKE_CURRENT_BINARY_DIR}/lexer.c")
+	${FLEX_lexer_OUTPUTS})
 
 if(BUILD_POCO)
   set(Poco_LIBRARIES PocoNetSSL PocoCrypto PocoNet PocoUtil PocoJSON PocoXML PocoFoundation)

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -18,6 +18,7 @@
 %option extra-type="struct deepstream_parser_state*"
 %option 8bit
 %option fast
+%option header-file="lexer.h"
 
 
 %{

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -28,7 +28,7 @@
 #include <deepstream/use.hpp>
 
 extern "C" {
-#include <lexer.h>
+#include "lexer.h"
 }
 
 #include <cassert>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,32 +31,19 @@ function(add_boost_test FILENAME DEPENDENCY_LIB)
 	endforeach()
 endfunction()
 
-
-include_directories("${CMAKE_BINARY_DIR}/include")
-
-
-# lexer testing
-add_custom_command(
-	OUTPUT
-	${CMAKE_CURRENT_BINARY_DIR}/test_lexer.c
-	${CMAKE_BINARY_DIR}/include/test_lexer.h
-	DEPENDS ${CMAKE_SOURCE_DIR}/src/lexer.l
-	COMMAND ${FLEX_EXECUTABLE}
-		--outfile=${CMAKE_CURRENT_BINARY_DIR}/test_lexer.c
-		--header-file=${CMAKE_BINARY_DIR}/include/test_lexer.h
-		-- ${CMAKE_SOURCE_DIR}/src/lexer.l
-	COMMENT "[FLEX][test] Building lexer with Flex ${FLEX_VERSION}"
-	VERBATIM
-)
+flex_target(lexer
+  ${CMAKE_SOURCE_DIR}/src/lexer.l
+  ${CMAKE_CURRENT_BINARY_DIR}/lexer.c)
 
 set_source_files_properties(
-	"${CMAKE_CURRENT_BINARY_DIR}/test_lexer.c"
+	"${CMAKE_CURRENT_BINARY_DIR}/lexer.c"
 	PROPERTIES
 		COMPILE_DEFINITIONS "_POSIX_SOURCE"
 		COMPILE_FLAGS "-Wno-unused-function -Wno-unused-parameter -Wno-type-limits -Wno-sign-compare"
 )
 
-add_library(test_lexer test_lexer.c)
+add_library(test_lexer ${FLEX_lexer_OUTPUTS})
+
 target_compile_definitions(test_lexer PUBLIC -DDEEPSTREAM_TEST_LEXER)
 
 add_boost_test(lexer.cpp test_lexer)

--- a/test/lexer.cpp
+++ b/test/lexer.cpp
@@ -24,7 +24,7 @@
 #include <deepstream/parser.h>
 
 extern "C" {
-#include <test_lexer.h>
+#include "lexer.h"
 }
 
 struct State {

--- a/test/parser.cpp
+++ b/test/parser.cpp
@@ -32,7 +32,7 @@
 #include <deepstream/scope_guard.hpp>
 
 extern "C" {
-#include <lexer.h>
+#include "lexer.h"
 }
 
 // Remarks:


### PR DESCRIPTION
Rely on the standard CMake flex_target() function to build the lexer
components in lieu of custom commands. Additionally include the
generated lexer.h using double-quotes (i.e., #include "lexer.h") and
ensure that the generated headers are not installed into
INSTALL_DIR/include.

Note: we would like to use DEFINES_FILE from the flex_target() macros
but that is only available in cmake >= 3.5. To workaround this we use
the '%option header-file="lexer.h"' option to specify and generate the
header file.

Closes #84.

Signed-off-by: Andrew McDermott <aim@frobware.com>