### PR TITLE
Use separate flex_target name for test directory

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,7 +31,7 @@ function(add_boost_test FILENAME DEPENDENCY_LIB)
 	endforeach()
 endfunction()
 
-flex_target(lexer
+flex_target(test_lexer
   ${CMAKE_SOURCE_DIR}/src/lexer.l
   ${CMAKE_CURRENT_BINARY_DIR}/lexer.c)
 
@@ -42,7 +42,7 @@ set_source_files_properties(
 		COMPILE_FLAGS "-Wno-unused-function -Wno-unused-parameter -Wno-type-limits -Wno-sign-compare"
 )
 
-add_library(test_lexer ${FLEX_lexer_OUTPUTS})
+add_library(test_lexer ${FLEX_test_lexer_OUTPUTS})
 
 target_compile_definitions(test_lexer PUBLIC -DDEEPSTREAM_TEST_LEXER)
 


### PR DESCRIPTION
This is a correction/addition/clarification on top of:

    8fdf6e41cd49941e109f1468a7836b9f386409a6

Signed-off-by: Andrew McDermott <aim@frobware.com>