### PR TITLE
Remove config.h.in from INSTALL_DIR/include/deepstream

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ set(PROJECT_VERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake/modules)
 
+configure_file(version.hpp.in ${CMAKE_BINARY_DIR}/include/deepstream/version.hpp @ONLY)
+
 # Put the libaries and binaries that get built into directories at the
 # top of the build tree rather than in hard-to-find leaf directories.
 
@@ -118,7 +120,7 @@ find_package(FLEX 2.5 REQUIRED)
 link_directories(${CMAKE_BINARY_DIR}/thirdparty/lib)
 include_directories(${CMAKE_BINARY_DIR}/thirdparty/include)
 
-include_directories("include")
+include_directories(${CMAKE_SOURCE_DIR}/include ${CMAKE_BINARY_DIR}/include)
 
 if(SWIG_FOUND)
   # We need to fix the generated Swig wrapper as the current version
@@ -152,13 +154,23 @@ if(SWIG_FOUND)
 endif()
 
 add_subdirectory(doc)
-add_subdirectory(include)
 add_subdirectory(src)
 add_subdirectory(examples)
 
 if(BUILD_TESTING AND Boost_FOUND)
   add_subdirectory(test)
 endif()
+
+INSTALL(
+    DIRECTORY ${CMAKE_SOURCE_DIR}/include/
+    DESTINATION include
+    FILES_MATCHING PATTERN "*.hpp"
+)
+
+INSTALL(
+    FILES ${CMAKE_BINARY_DIR}/include/deepstream/version.hpp
+    DESTINATION include/deepstream
+)
 
 message(STATUS "CMAKE_SYSTEM=${CMAKE_SYSTEM}")
 message(STATUS "CMAKE_SYSTEM_NAME=${CMAKE_SYSTEM_NAME}")

--- a/deepstream.i
+++ b/deepstream.i
@@ -27,4 +27,5 @@ wrap_unique_ptr(deepstreamClientUniquePtr, deepstream::Client);
 %include "deepstream/presence.hpp"
 %include "deepstream/event.hpp"
 %include "deepstream/client.hpp"
+%include "deepstream/version.hpp"
 %include "deepstream.hpp"

--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -1,8 +1,0 @@
-add_subdirectory(deepstream)
-
-install(
-	DIRECTORY ./
-	DESTINATION "include"
-	FILES_MATCHING REGEX ".+[.](h|hpp)"
-	PATTERN "lexer.h" EXCLUDE
-)

--- a/include/deepstream.hpp
+++ b/include/deepstream.hpp
@@ -23,7 +23,7 @@
 
 #include <deepstream/buffer.hpp>
 #include <deepstream/client.hpp>
-#include <deepstream/config.h>
+#include <deepstream/version.hpp>
 #include <deepstream/event.hpp>
 #include <deepstream/presence.hpp>
 
@@ -37,18 +37,6 @@ namespace client {
 namespace impl {
     struct Client;
 }
-
-struct version {
-    version() = delete;
-
-    enum {
-        MAJOR = DEEPSTREAM_VERSION_MAJOR,
-        MINOR = DEEPSTREAM_VERSION_MINOR,
-        PATCH = DEEPSTREAM_VERSION_PATCH
-    };
-
-    static constexpr const char* to_string() { return DEEPSTREAM_VERSION; }
-};
 
 // This class does not use `std::unique_ptr<impl::Client>` because it
 // prevents the use of the PIMPL idiom because the class attempts to

--- a/include/deepstream/CMakeLists.txt
+++ b/include/deepstream/CMakeLists.txt
@@ -1,6 +1,0 @@
-configure_file(config.h.in config.h @ONLY)
-
-install(
-	FILES "${CMAKE_BINARY_DIR}/include/deepstream/config.h"
-	DESTINATION "include/deepstream"
-)

--- a/version.hpp.in
+++ b/version.hpp.in
@@ -13,12 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef DEEPSTREAM_CONFIG_H
-#define DEEPSTREAM_CONFIG_H
+#ifndef DEEPSTREAM_VERSION_H
+#define DEEPSTREAM_VERSION_H
 
 #define DEEPSTREAM_VERSION_MAJOR @PROJECT_VERSION_MAJOR@
 #define DEEPSTREAM_VERSION_MINOR @PROJECT_VERSION_MINOR@
 #define DEEPSTREAM_VERSION_PATCH @PROJECT_VERSION_PATCH@
 #define DEEPSTREAM_VERSION "@PROJECT_VERSION@"
+
+namespace deepstream {
+
+struct version {
+    version() = delete;
+
+    enum {
+        MAJOR = DEEPSTREAM_VERSION_MAJOR,
+        MINOR = DEEPSTREAM_VERSION_MINOR,
+        PATCH = DEEPSTREAM_VERSION_PATCH
+    };
+
+    static constexpr const char* to_string() { return DEEPSTREAM_VERSION; }
+};
+
+}
 
 #endif


### PR DESCRIPTION
This pass removes config.h.in from the list of files that get included
into INSTALL_DIR/include/deepstream. This commit also removes
CMakeFiles.txt from both src/include and src/include/deepstream which
simultaneously removes a lot of cmake build files from the installed
tree.

config.h.in actually represented version information. As such, this
has now been renamed version.hpp.in and I moved the version class out
of [some arbitrary] header file into version.hpp so there should be no
surprises to find only version information in that file.

If you run `make install` the installed tree now looks like:

    $ tree /tmp/ds/include/
    /tmp/ds/include/
    ├── deepstream
    │   ├── buffer.hpp
    │   ├── client.hpp
    │   ├── error_handler.hpp
    │   ├── event.hpp
    │   ├── exception.hpp
    │   ├── impl.hpp
    │   ├── message_builder.hpp
    │   ├── message.hpp
    │   ├── message_proxy.hpp
    │   ├── parser.hpp
    │   ├── presence.hpp
    │   ├── random.hpp
    │   ├── scope_guard.hpp
    │   ├── time.hpp
    │   ├── use.hpp
    │   ├── version.hpp
    │   ├── websockets
    │   │   ├── poco.hpp
    │   │   └── pseudo.hpp
    │   └── websockets.hpp
    └── deepstream.hpp

Closes #90.

Signed-off-by: Andrew McDermott <aim@frobware.com>