### PR TITLE
swig: simplify included headers

### DIFF
--- a/deepstream.i
+++ b/deepstream.i
@@ -2,10 +2,6 @@
 
 %{
 #include "deepstream.hpp"
-#include "deepstream/buffer.hpp"
-#include "deepstream/exception.hpp"
-#include "deepstream/client.hpp"
-#include "deepstream/presence.hpp"
 #include "deepstream/error_handler.hpp"
 %}
 


### PR DESCRIPTION
By including `deepstream.hpp` we already have a lot of the public API
included. This commit reduces the include set to just relying on the
convenience header and error handler header.

Signed-off-by: Andrew McDermott <aim@frobware.com>