### PR TITLE
Partially revert "Use flex_target for building lexer components"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,9 +3,18 @@ find_package(Threads REQUIRED)
 
 find_package(OpenSSL REQUIRED)
 
-flex_target(lexer
-  ${CMAKE_SOURCE_DIR}/src/lexer.l
-  ${CMAKE_CURRENT_BINARY_DIR}/lexer.c)
+add_custom_command(
+	OUTPUT
+		${CMAKE_CURRENT_BINARY_DIR}/lexer.c
+		${CMAKE_CURRENT_BINARY_DIR}/lexer.h
+	DEPENDS ${CMAKE_SOURCE_DIR}/src/lexer.l
+	COMMAND ${FLEX_EXECUTABLE}
+		--outfile=${CMAKE_CURRENT_BINARY_DIR}/lexer.c
+		--header-file=${CMAKE_CURRENT_BINARY_DIR}/lexer.h
+		-- ${CMAKE_SOURCE_DIR}/src/lexer.l
+	COMMENT "[FLEX][src] Building lexer with Flex ${FLEX_VERSION}"
+	VERBATIM
+)
 
 set_source_files_properties(
 	"${CMAKE_CURRENT_BINARY_DIR}/lexer.c"
@@ -31,14 +40,14 @@ add_library(
 	websockets.cpp
 	websockets/poco.cpp
 	websockets/pseudo.cpp
-	${FLEX_lexer_OUTPUTS})
+	"${CMAKE_CURRENT_BINARY_DIR}/lexer.c")
 
 if(BUILD_POCO)
   set(Poco_LIBRARIES PocoNetSSL PocoCrypto PocoNet PocoUtil PocoJSON PocoXML PocoFoundation)
 endif()
 
 set_target_properties(libdeepstream PROPERTIES OUTPUT_NAME deepstream)
-target_include_directories(libdeepstream PUBLIC "${CMAKE_BINARY_DIR}/include")
+target_include_directories(libdeepstream PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(libdeepstream PUBLIC ${Poco_LIBRARIES} ${OPENSSL_LIBRARIES} Threads::Threads)
 install(TARGETS libdeepstream DESTINATION "lib")
 

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -18,7 +18,6 @@
 %option extra-type="struct deepstream_parser_state*"
 %option 8bit
 %option fast
-%option header-file="lexer.h"
 
 
 %{

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -28,7 +28,7 @@
 #include <deepstream/use.hpp>
 
 extern "C" {
-#include "lexer.h"
+#include <lexer.h>
 }
 
 #include <cassert>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,9 +31,18 @@ function(add_boost_test FILENAME DEPENDENCY_LIB)
 	endforeach()
 endfunction()
 
-flex_target(test_lexer
-  ${CMAKE_SOURCE_DIR}/src/lexer.l
-  ${CMAKE_CURRENT_BINARY_DIR}/lexer.c)
+add_custom_command(
+	OUTPUT
+		${CMAKE_CURRENT_BINARY_DIR}/lexer.c
+		${CMAKE_CURRENT_BINARY_DIR}/lexer.h
+	DEPENDS ${CMAKE_SOURCE_DIR}/src/lexer.l
+	COMMAND ${FLEX_EXECUTABLE}
+		--outfile=${CMAKE_CURRENT_BINARY_DIR}/lexer.c
+		--header-file=${CMAKE_CURRENT_BINARY_DIR}/lexer.h
+		-- ${CMAKE_SOURCE_DIR}/src/lexer.l
+	COMMENT "[FLEX][src] Building lexer with Flex ${FLEX_VERSION}"
+	VERBATIM
+)
 
 set_source_files_properties(
 	"${CMAKE_CURRENT_BINARY_DIR}/lexer.c"
@@ -42,8 +51,8 @@ set_source_files_properties(
 		COMPILE_FLAGS "-Wno-unused-function -Wno-unused-parameter -Wno-type-limits -Wno-sign-compare"
 )
 
-add_library(test_lexer ${FLEX_test_lexer_OUTPUTS})
-
+add_library(test_lexer ${CMAKE_CURRENT_BINARY_DIR}/lexer.c)
+target_include_directories(test_lexer PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 target_compile_definitions(test_lexer PUBLIC -DDEEPSTREAM_TEST_LEXER)
 
 add_boost_test(lexer.cpp test_lexer)

--- a/test/lexer.cpp
+++ b/test/lexer.cpp
@@ -24,7 +24,7 @@
 #include <deepstream/parser.h>
 
 extern "C" {
-#include "lexer.h"
+#include <lexer.h>
 }
 
 struct State {


### PR DESCRIPTION
This partially reverts commit PR #87.

As we had to use older semantics of the flex_target()
function (because of the version of FindFLEX.cmake on trusty) it meant
that Flex's artifacts (lexer.c and lexer.h) polluted the source tree
during the build. By reverting we keep the essence of PR #87 and the
work done in PR #91 ensures that lexer.h does not end up in
INSTALL_DIR/include.

Signed-off-by: Andrew McDermott <aim@frobware.com>