### PR TITLE
Remove final libboost dependency in the library build

### DIFF
--- a/src/scope_guard.hpp
+++ b/src/scope_guard.hpp
@@ -18,8 +18,6 @@
 
 #include <functional>
 
-#include <boost/preprocessor/cat.hpp>
-
 #include "use.hpp"
 
 namespace deepstream {
@@ -50,9 +48,10 @@ struct ScopeGuard {
 };
 }
 
-#define DEEPSTREAM_ON_EXIT(...)                                   \
-    const ::deepstream::ScopeGuard BOOST_PP_CAT(deepstream_guard, \
-        __LINE__)(__VA_ARGS__);                                   \
-    ::deepstream::use(BOOST_PP_CAT(deepstream_guard, __LINE__))
+#define DEEPSTREAM_TOKENPASTE(x, y) x##y
+#define DEEPSTREAM_TOKENPASTE2(x, y) DEEPSTREAM_TOKENPASTE(x, y)
+
+#define DEEPSTREAM_ON_EXIT(...) \
+    const ::deepstream::ScopeGuard DEEPSTREAM_TOKENPASTE2(_deepstream_guard_gensym_, __LINE__)(__VA_ARGS__)
 
 #endif


### PR DESCRIPTION
The last remaining dependency was using Boost's PP_CAT
macro (pre-processor concatenation macro) which is easy enough to
concoct without Boost.

Closes #95.

Signed-off-by: Andrew McDermott <aim@frobware.com>